### PR TITLE
Issue #13 - PHP7.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ language: php
 php:
   - 7.2
   - 7.3
-install:
-  - composer install
 before_script:
-  - composer install --no-dev
+  - composer install
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
-  - ./vendor/bin/phpunit --bootstrap test/phpunit/bootstrap.php test/phpunit/ --coverage-text --coverage-clover build/logs/clover.xml"
+  - "./vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml"
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build  -t clover --exit-code $TRAVIS_TEST_RESULT; fi
 notifications:
   on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=abed2d50d475d83eba12c9da272bf733e0692aeafdfcb0b79846e90fe1c1abf7
+    - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
 language: php
 php:
-- 7.0
-- 7.1
-- 7.2
+  - 7.2
+  - 7.3
 install:
-- composer install
+  - composer install
+before_script:
+  - composer install --no-dev
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
-- ./vendor/bin/phpunit --bootstrap test/phpunit/bootstrap.php test/phpunit/
+  - ./vendor/bin/phpunit --bootstrap test/phpunit/bootstrap.php test/phpunit/ --coverage-text --coverage-clover build/logs/clover.xml"
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build  -t clover --exit-code $TRAVIS_TEST_RESULT; fi
 notifications:
   on_success: never
   on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Anime News Network Data Client
-[![Build Status](http://travis-ci.org/sprak3000/AnimeNewsNetworkDataAPI.svg)](http://github.com/sprak3000/AnimeNewsNetworkDataAPI)
+[![Build Status](https://travis-ci.org/sprak3000/AnimeNewsNetworkDataAPI.svg?branch=master)](https://travis-ci.org/sprak3000/AnimeNewsNetworkDataAPI)
+[![Maintainability](https://api.codeclimate.com/v1/badges/8f0ca6dec4db4f17da14/maintainability)](https://codeclimate.com/github/sprak3000/AnimeNewsNetworkDataAPI/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/8f0ca6dec4db4f17da14/test_coverage)](https://codeclimate.com/github/sprak3000/AnimeNewsNetworkDataAPI/test_coverage)
 
 This is a PHP client wrapper for the [Anime News Network](http://www.animenewsnetwork.com/encyclopedia/api.php) data
 API. If you are interested in contributing back to this project, feel free to read the *Contributing* documentation
@@ -12,7 +14,7 @@ When using this client to retrieve data, you must still abide by the ANN API ter
 source of the data and link to Anime News Network on every page that incorporates data from the API.
 
 ## Requires
-* PHP 7
+* PHP >= 7.2
 * [Composer](https://getcomposer.org/) (to install this library)
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "url": "http://github.com/sprak3000/guzzle-services"
   }],
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.2",
     "guzzlehttp/guzzle": "6.*",
     "guzzlehttp/guzzle-services": "1.*"
   },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="test/phpunit/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>./test/phpunit</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+            <exclude>
+                <directory>./vendor</directory>
+                <directory>./doc</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,7 +19,7 @@ use GuzzleHttp\Command\Model;
  */
 class Client extends GuzzleClient
 {
-    const DEFAULT_API_URL = 'http://cdn.animenewsnetwork.com/encyclopedia/api.xml';
+    const DEFAULT_API_URL = 'https://cdn.animenewsnetwork.com/encyclopedia/api.xml';
 
     /**
      * Constructor

--- a/test/phpunit/ClientTest.php
+++ b/test/phpunit/ClientTest.php
@@ -34,6 +34,6 @@ class ClientTest extends TestCase
 
         $this->assertInstanceOf('GuzzleHttp\Psr7\Uri', $base);
         $this->assertEquals('cdn.animenewsnetwork.com', $host);
-        $this->assertEquals('http://cdn.animenewsnetwork.com/encyclopedia/api.xml', $uri);
+        $this->assertEquals('https://cdn.animenewsnetwork.com/encyclopedia/api.xml', $uri);
     }
 }


### PR DESCRIPTION
* Update TravisCI configuration to run tests against PHP 7.2 & 7.3.
* Update TravisCI configuration and add `phpunit` configuration file to perform CodeClimate test coverage reporting.
* Update `composer.json` to have the library require PHP 7.2 or higher.
* Update `README` to indicate new PHP requirement.